### PR TITLE
Fix race condition & update mod build package

### DIFF
--- a/PondWithBridge/PondWithBridge.cs
+++ b/PondWithBridge/PondWithBridge.cs
@@ -9,37 +9,23 @@ namespace PondWithBridge
 {
     public class PondWithBridge : Mod
     {
-
-        public static bool farmModified = false;
-
         /// <summary>The mod entry point, called after the mod is first loaded.</summary>
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
-            GameEvents.SecondUpdateTick += Event_SecondUpdateTick;
+            SaveEvents.AfterLoad += SaveEvents_AfterLoad;
         }
 
-        private void Event_SecondUpdateTick(object sender, EventArgs e)
+        private void SaveEvents_AfterLoad(object sender, EventArgs e)
         {
+            Farm farm = Game1.getFarm();
+            farm.map.AddTileSheet(new TileSheet("Z", farm.map, Helper.Content.GetActualAssetKey("spring_town", ContentSource.GameContent), new xTile.Dimensions.Size(32, 62), new xTile.Dimensions.Size(16, 16)));
+            farm.map.LoadTileSheets(Game1.mapDisplayDevice);
 
-            if (Game1.hasLoadedGame && !farmModified)
-            {
-                Farm bridge = (Farm)Game1.getLocationFromName("Farm");
-                if (bridge != null)
-                {
-
-                    bridge.map.AddTileSheet(new TileSheet("Z", bridge.map, "..\\content\\spring_town", new xTile.Dimensions.Size(32, 62), new xTile.Dimensions.Size(16, 16)));
-                    bridge.map.LoadTileSheets(Game1.mapDisplayDevice);
-
-                    PatchMap(bridge, BridgeEdits);
-                    farmModified = true;
-
-                    GameEvents.UpdateTick -= Event_SecondUpdateTick;
-                }
-            }
+            PatchMap(farm, BridgeEdits);
         }
 
-        private static List<Tile> BridgeEdits = new List<Tile>()
+        private readonly List<Tile> BridgeEdits = new List<Tile>
         {
             //---tiles to null---
             new Tile(0, 40, 48, -1), new Tile(0, 41, 48, -1), //negative 1 layer
@@ -80,8 +66,8 @@ namespace PondWithBridge
 
         };
 
-      
-        private static void PatchMap(GameLocation gl, List<Tile> tileArray)
+
+        private void PatchMap(GameLocation gl, List<Tile> tileArray)
         {
             foreach (Tile tile in tileArray)
             {
@@ -89,7 +75,7 @@ namespace PondWithBridge
                 {
                     gl.removeTile(tile.x, tile.y, tile.layer);
                     gl.waterTiles[tile.x, tile.y] = false;
-                    
+
                     continue;
                 }
 

--- a/PondWithBridge/PondWithBridge.csproj
+++ b/PondWithBridge/PondWithBridge.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>PondWithBridge</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,11 +43,11 @@
     <None Include="release-notes.md" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/PondWithBridge/manifest.json
+++ b/PondWithBridge/manifest.json
@@ -7,6 +7,7 @@
     "PatchVersion": 1,
     "Build": null
   },
+  "MinimumApiVersion": "1.15",
   "Description": "Adds a bridge over the lower pond on the farm",
   "UniqueID": "jinxiewinxie.StoneBridgeOverPond",
   "EntryDll": "PondWithBridge.dll",

--- a/PondWithBridge/manifest.json
+++ b/PondWithBridge/manifest.json
@@ -4,7 +4,7 @@
   "Version": {
     "MajorVersion": 1,
     "MinorVersion": 0,
-    "PatchVersion": 1,
+    "PatchVersion": 2,
     "Build": null
   },
   "MinimumApiVersion": "1.15",

--- a/PondWithBridge/packages.config
+++ b/PondWithBridge/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.1" targetFramework="net452" />
 </packages>

--- a/TaintedCellar/TaintedCellar.csproj
+++ b/TaintedCellar/TaintedCellar.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>TaintedCellar</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -63,11 +62,11 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/TaintedCellar/manifest.json
+++ b/TaintedCellar/manifest.json
@@ -11,5 +11,5 @@
   "Description": "Adds an underground cellar, complete with amenities only found in bomb shelters owned by paranoid survivalists or Cold War homeowners!",
   "UniqueID": "TaintedCellar",
   "EntryDll": "TaintedCellar.dll",
-  "UpdateKeys": [ "" ]
+  "UpdateKeys": [ ]
 }

--- a/TaintedCellar/packages.config
+++ b/TaintedCellar/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.1" targetFramework="net45" />
 </packages>

--- a/WonderfulFarmLife/WonderfulFarmLife.csproj
+++ b/WonderfulFarmLife/WonderfulFarmLife.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>WonderfulFarmLife</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -77,11 +76,11 @@
     <None Include="release-notes.md" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/WonderfulFarmLife/manifest.json
+++ b/WonderfulFarmLife/manifest.json
@@ -10,5 +10,5 @@
   "Description": "Adds a bunch of map edits to your farm",
   "UniqueID": "WonderfulFarmLife",
   "EntryDll": "WonderfulFarmLife.dll",
-  "UpdateKeys": [ "" ]
+  "UpdateKeys": [ ]
 }

--- a/WonderfulFarmLife/packages.config
+++ b/WonderfulFarmLife/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This pull request...

* Fixes a race condition that causes intermittent crashes when loading saves.

  The issue is that the the mod adds a tilesheet to the farm map as soon as it's available, which sometimes happens when the map is still loading its tilesheets. That causes an error in the game's loading code:
  ```
  System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
     at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
     at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
     at System.Collections.Generic.List`1.Enumerator.MoveNext()
     at xTile.Map.LoadTileSheets(IDisplayDevice displayDevice)
     at StardewValley.Game1.setGraphicsForSeason()
     at StardewValley.Game1.loadForNewGame(Boolean loadedGame)
     at StardewValley.SaveGame.<>c.<getLoadEnumerator>b__51_1()
     at System.Threading.Tasks.Task.InnerInvoke()
     at System.Threading.Tasks.Task.Execute()
  ```
  This PR moves the patch code into `SaveEvents.AfterLoad`, which is called after the save is fully loaded.

* Simplifies the code a bit using newer SMAPI features.
* Updates the mod build package, which makes it easier to copy the mod into the `Mods` folder and automatically creates a release zip in the build output.